### PR TITLE
使用原生 Editor 拓展替代 Odin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ Docs/
 Assets/Plugins/Rosetta/package.json
 Assets/Plugins/Rosetta/package.json.meta
 Assets/Plugins/Rosetta/.gitignore
+
+# VSC
+.vscode/

--- a/Assets/Plugins/Rosetta/Editor/Collector/CollectorBase.cs
+++ b/Assets/Plugins/Rosetta/Editor/Collector/CollectorBase.cs
@@ -4,27 +4,24 @@ using System.Linq;
 using Rosetta.Editor.Creator;
 using Rosetta.Runtime;
 using Rosetta.Runtime.Loader;
-using Sirenix.OdinInspector;
-using Sirenix.Utilities;
 using UnityEngine;
 
 namespace Rosetta.Editor.Collector
 {
-    [Serializable, HideInEditorMode]
-    public abstract class CollectorBase
+    public abstract class CollectorBase : ScriptableObject
     {
         private static List<Type> _i18NClass;
-        
-        [HideInInspector] 
+
+        [HideInInspector]
         public Dictionary<string, I18NMedia<AudioClip>> I18NAudios;
 
-        [HideInInspector] 
+        [HideInInspector]
         public Dictionary<string, I18NMedia<Sprite>> I18NImages;
 
-        [HideInInspector] 
+        [HideInInspector]
         public Dictionary<string, I18NMedia<FontInfo>> I18NFonts;
 
-        [HideInInspector] 
+        [HideInInspector]
         public Dictionary<string, I18NMedia<string>> I18NStrings;
 
         public static List<Type> I18NClass => _i18NClass ?? (_i18NClass = GetI18NClass());
@@ -33,13 +30,18 @@ namespace Rosetta.Editor.Collector
 
         private static List<Type> GetI18NClass()
         {
-            var subclasses =
-                from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                from type in assembly.GetTypes()
-                from attr in type.GetAttributes()
-                where attr.GetType() == typeof(I18NClassAttribute)
-                select type;
-            return subclasses.ToList();
+            // var subclasses =
+            //     from assembly in AppDomain.CurrentDomain.GetAssemblies()
+            //     from type in assembly.GetTypes()
+            //     from attr in type.Attributes
+            //     where attr.GetType() == typeof(I18NClassAttribute)
+            //     select type;
+            // return subclasses.ToList();
+            return AppDomain.CurrentDomain.GetAssemblies().SelectMany(assem =>
+                assem.GetTypes().Where(type =>
+                    type.CustomAttributes.Any(attr =>
+                        attr.AttributeType == typeof(I18NClassAttribute)))
+            ).ToList();
         }
     }
 }

--- a/Assets/Plugins/Rosetta/Editor/Collector/PrefabCollector.cs
+++ b/Assets/Plugins/Rosetta/Editor/Collector/PrefabCollector.cs
@@ -1,14 +1,12 @@
 using System;
 using System.Collections.Generic;
-using Sirenix.OdinInspector;
 using UnityEngine;
 
 namespace Rosetta.Editor.Collector
 {
-    [Serializable]
     public class PrefabCollector : PrefabCollectorBase
     {
-        [AssetsOnly]
+        // [AssetsOnly]
         public List<GameObject> PrefabList = new List<GameObject>();
 
         public override void Collect(string space)

--- a/Assets/Plugins/Rosetta/Editor/Collector/PrefabCollectorBase.cs
+++ b/Assets/Plugins/Rosetta/Editor/Collector/PrefabCollectorBase.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Rosetta.Editor.Creator;
 using Rosetta.Runtime.Component;
+using Rosetta.Editor.Creator;
 using Rosetta.Runtime.Loader;
 using TMPro;
 using UnityEngine;

--- a/Assets/Plugins/Rosetta/Editor/Collector/SceneCollector.cs
+++ b/Assets/Plugins/Rosetta/Editor/Collector/SceneCollector.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEditor.SceneManagement;
+using UnityEngine;
 
 
 namespace Rosetta.Editor.Collector
 {
-    [Serializable]
     public class SceneCollector : PrefabCollectorBase
     {
         public List<SceneAsset> SceneList = new List<SceneAsset>();

--- a/Assets/Plugins/Rosetta/Editor/Collector/ScriptableObjectCollector.cs
+++ b/Assets/Plugins/Rosetta/Editor/Collector/ScriptableObjectCollector.cs
@@ -1,24 +1,23 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Rosetta.Editor.Creator;
 using Rosetta.Runtime;
-using Sirenix.OdinInspector;
-using Sirenix.Utilities;
+using Rosetta.Utils;
 using UnityEditor;
 using UnityEngine;
 
 namespace Rosetta.Editor.Collector
 {
-    [Serializable]
     public class ScriptableObjectCollector : CollectorBase
     {
         [FolderPath]
         public string DataFolderPath = "Data/Resources";
-        [InlineButton("Refresh")]
+        // [InlineButton("Refresh")]
         public List<ScriptableObject> DataList = new List<ScriptableObject>();
 
-        private void Refresh()
+        public void Refresh()
         {
             DataList.Clear();
             var guids = AssetDatabase.FindAssets("t:" + typeof(ScriptableObject).Name, new[] {DataFolderPath});
@@ -59,13 +58,13 @@ namespace Rosetta.Editor.Collector
         {
             var fields =
                 from field in classType.GetFields()
-                from attr in field.GetAttributes()
+                from attr in field.GetCustomAttributes(true)
                 where attr is I18NStringAttribute
                 select field;
             fields.ForEach(field =>
             {
                 var path =
-                    $"Database[{type.ToString()}]:/InstanceID:{obj.GetInstanceID()}/FieldName:{field.Name}";
+                    $"Database[{type}]:/InstanceID:{obj.GetInstanceID()}/FieldName:{field.Name}";
                 var text = field.GetValue(obj) as string;
 
                 if (I18NStrings.ContainsKey(text ?? throw new InvalidOperationException()))
@@ -76,7 +75,7 @@ namespace Rosetta.Editor.Collector
                 {
                     var i18NString = new I18NMedia<string>
                     {
-                        Comment = field.GetAttribute<I18NStringAttribute>().Comment,
+                        Comment = field.GetCustomAttribute<I18NStringAttribute>().Comment,
                         PathList = new List<string> {path},
                         Value = text
                     };
@@ -88,7 +87,7 @@ namespace Rosetta.Editor.Collector
         private void I18NStringListPass(Type classType, Type type, ScriptableObject obj)
         {
             var fields = from field in classType.GetFields()
-                from attr in field.GetAttributes()
+                from attr in field.GetCustomAttributes()
                 where attr is I18NStringListAttribute
                 select field;
             fields.ForEach(field =>
@@ -106,7 +105,7 @@ namespace Rosetta.Editor.Collector
                         {
                             var i18NString = new I18NMedia<string>
                             {
-                                Comment = field.GetAttribute<I18NStringListAttribute>().Comment,
+                                Comment = field.GetCustomAttribute<I18NStringListAttribute>().Comment,
                                 PathList = new List<string> {path},
                                 Value = text
                             };
@@ -119,7 +118,7 @@ namespace Rosetta.Editor.Collector
         private void I18NAudioPass(Type classType, Type type, ScriptableObject obj)
         {
             var fields = from field in classType.GetFields()
-                from attr in field.GetAttributes()
+                from attr in field.GetCustomAttributes()
                 where attr is I18NAudioAttribute
                 select field;
             fields.ForEach(field =>
@@ -137,7 +136,7 @@ namespace Rosetta.Editor.Collector
                 {
                     var i18NAudio = new I18NMedia<AudioClip>
                     {
-                        Comment = field.GetAttribute<I18NAudioAttribute>().Comment,
+                        Comment = field.GetCustomAttribute<I18NAudioAttribute>().Comment,
                         PathList = new List<string> {path},
                         Value = value
                     };
@@ -149,7 +148,7 @@ namespace Rosetta.Editor.Collector
         private void I18NAudioListPass(Type classType, Type type, ScriptableObject obj)
         {
             var fields = from field in classType.GetFields()
-                from attr in field.GetAttributes()
+                from attr in field.GetCustomAttributes()
                 where attr is I18NAudioListAttribute
                 select field;
             fields.ForEach(field =>
@@ -168,7 +167,7 @@ namespace Rosetta.Editor.Collector
                     {
                         var i18NAudio = new I18NMedia<AudioClip>
                         {
-                            Comment = field.GetAttribute<I18NAudioListAttribute>().Comment,
+                            Comment = field.GetCustomAttribute<I18NAudioListAttribute>().Comment,
                             PathList = new List<string> {path},
                             Value = audio
                         };
@@ -181,7 +180,7 @@ namespace Rosetta.Editor.Collector
         private void I18NImagePass(Type classType, Type type, ScriptableObject obj)
         {
             var fields = from field in classType.GetFields()
-                from attr in field.GetAttributes()
+                from attr in field.GetCustomAttributes()
                 where attr is I18NImageAttribute
                 select field;
             fields.ForEach(field =>
@@ -199,7 +198,7 @@ namespace Rosetta.Editor.Collector
                 {
                     var i18NImage = new I18NMedia<Sprite>
                     {
-                        Comment = field.GetAttribute<I18NImageAttribute>().Comment,
+                        Comment = field.GetCustomAttribute<I18NImageAttribute>().Comment,
                         PathList = new List<string> {path},
                         Value = value
                     };
@@ -211,7 +210,7 @@ namespace Rosetta.Editor.Collector
         private void I18NImageListPass(Type classType, Type type, ScriptableObject obj)
         {
             var fields = from field in classType.GetFields()
-                from attr in field.GetAttributes()
+                from attr in field.GetCustomAttributes()
                 where attr is I18NImageListAttribute
                 select field;
             fields.ForEach(field =>
@@ -230,7 +229,7 @@ namespace Rosetta.Editor.Collector
                     {
                         var i18NImage = new I18NMedia<Sprite>
                         {
-                            Comment = field.GetAttribute<I18NImageListAttribute>().Comment,
+                            Comment = field.GetCustomAttribute<I18NImageListAttribute>().Comment,
                             PathList = new List<string> {path},
                             Value = image
                         };

--- a/Assets/Plugins/Rosetta/Editor/Creator.meta
+++ b/Assets/Plugins/Rosetta/Editor/Creator.meta
@@ -1,3 +1,8 @@
-﻿fileFormatVersion: 2
-guid: d6c25e0713fb41fc97eba778334258f6
-timeCreated: 1566615173
+fileFormatVersion: 2
+guid: 5351055ff3b213141b022963670c397d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Rosetta/Editor/Creator/CreatorBase.cs
+++ b/Assets/Plugins/Rosetta/Editor/Creator/CreatorBase.cs
@@ -2,7 +2,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using Rosetta.Editor.Collector;
-using Sirenix.OdinInspector;
+using Rosetta.Runtime;
+using UnityEngine;
 
 namespace Rosetta.Editor.Creator
 {
@@ -21,15 +22,15 @@ namespace Rosetta.Editor.Creator
     }
         
     
-    public abstract class CreatorBase : SerializedScriptableObject
+    public abstract class CreatorBase : ScriptableObject
     {
+        [HideInInspector]
         public List<CollectorBase> Collectors = new List<CollectorBase>();
         public string Name;
         [FolderPath] public string OutputPath;
 
         protected abstract void _create();
 
-        [Button(ButtonSizes.Medium, Name = "Create I18N file")]
         public void Create()
         {
             _create();

--- a/Assets/Plugins/Rosetta/Editor/Creator/MediaCreator.cs
+++ b/Assets/Plugins/Rosetta/Editor/Creator/MediaCreator.cs
@@ -5,7 +5,7 @@ using Rosetta.Editor.Collector;
 using UnityEngine;
 using UnityEditor;
 using Rosetta.Runtime.Loader;
-using Sirenix.Utilities;
+using Rosetta.Utils;
 
 namespace Rosetta.Editor.Creator
 {

--- a/Assets/Plugins/Rosetta/Editor/Custom.meta
+++ b/Assets/Plugins/Rosetta/Editor/Custom.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9026c6b39d9c79f4590355dcf7478227
+guid: 5cb302944d2acf148ba0f985ca5a5db0
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Plugins/Rosetta/Editor/Custom/Collector.meta
+++ b/Assets/Plugins/Rosetta/Editor/Custom/Collector.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9026c6b39d9c79f4590355dcf7478227
+guid: 33172544199a01a4aa406b9c1cde0de7
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Plugins/Rosetta/Editor/Custom/Collector/ScriptableObjectCollectorEditor.cs
+++ b/Assets/Plugins/Rosetta/Editor/Custom/Collector/ScriptableObjectCollectorEditor.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+using UnityEditor;
+using Rosetta.Editor.Collector;
+
+namespace Rosetta.Editor.Custom.Collector
+{
+    [CustomEditor(typeof(ScriptableObjectCollector))]
+    public class ScriptableObjectCollectorEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+            if (GUILayout.Button("Refresh"))
+                (target as ScriptableObjectCollector).Refresh();
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/Plugins/Rosetta/Editor/Custom/Collector/ScriptableObjectCollectorEditor.cs.meta
+++ b/Assets/Plugins/Rosetta/Editor/Custom/Collector/ScriptableObjectCollectorEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a273296703056b4489accef0dfa76f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Rosetta/Editor/Custom/Component.meta
+++ b/Assets/Plugins/Rosetta/Editor/Custom/Component.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9026c6b39d9c79f4590355dcf7478227
+guid: 3a765c99dae37874aa4cc607bbfb7de7
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Plugins/Rosetta/Editor/Custom/Component/I18NImageEditor.cs
+++ b/Assets/Plugins/Rosetta/Editor/Custom/Component/I18NImageEditor.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+using UnityEditor;
+using UnityEngine.UI;
+using Rosetta.Runtime.Component;
+
+namespace Rosetta.Editor.Component.Custom
+{
+    [CustomEditor(typeof(I18NImage))]
+    public class I18NImageEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+            if (EditorApplication.isPlaying) return;
+            TextureImporter textureImporter = AssetImporter.GetAtPath(AssetDatabase.GetAssetPath((target as GameObject).GetComponent<Image>().sprite.texture)) as TextureImporter;
+            if (!textureImporter.isReadable)
+                EditorGUILayout.HelpBox("The Image source sprite is not readable.", UnityEditor.MessageType.Error);
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/Plugins/Rosetta/Editor/Custom/Component/I18NImageEditor.cs.meta
+++ b/Assets/Plugins/Rosetta/Editor/Custom/Component/I18NImageEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8dbc206bf279f8545bd5d8591f0993ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Rosetta/Editor/Custom/Component/I18NTMPTextEditor.cs
+++ b/Assets/Plugins/Rosetta/Editor/Custom/Component/I18NTMPTextEditor.cs
@@ -1,0 +1,18 @@
+using UnityEditor;
+using Rosetta.Runtime.Component;
+
+namespace Rosetta.Editor.Component.Custom
+{
+    [CustomEditor(typeof(I18NTMPText))]
+    public class I18NTMPTextEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+            var showFont = serializedObject.FindProperty("IsVirtualFont");
+            EditorGUILayout.PropertyField(showFont);
+            if (showFont.boolValue) EditorGUILayout.PropertyField(serializedObject.FindProperty("VirtualFontName"));
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/Plugins/Rosetta/Editor/Custom/Component/I18NTMPTextEditor.cs.meta
+++ b/Assets/Plugins/Rosetta/Editor/Custom/Component/I18NTMPTextEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27749c3d15e3fb04b80d3c709f20f6b3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Rosetta/Editor/Custom/Component/I18NTextEditor.cs
+++ b/Assets/Plugins/Rosetta/Editor/Custom/Component/I18NTextEditor.cs
@@ -1,0 +1,18 @@
+using UnityEditor;
+using Rosetta.Runtime.Component;
+
+namespace Rosetta.Editor.Component.Custom
+{
+    [CustomEditor(typeof(I18NText))]
+    public class I18NTextEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+            var showFont = serializedObject.FindProperty("IsVirtualFont");
+            EditorGUILayout.PropertyField(showFont);
+            if (showFont.boolValue) EditorGUILayout.PropertyField(serializedObject.FindProperty("VirtualFontName"));
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/Plugins/Rosetta/Editor/Custom/Component/I18NTextEditor.cs.meta
+++ b/Assets/Plugins/Rosetta/Editor/Custom/Component/I18NTextEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2b44f5f6c40a86a4c99b5915612a5715
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Rosetta/Editor/Custom/Creator.meta
+++ b/Assets/Plugins/Rosetta/Editor/Custom/Creator.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9026c6b39d9c79f4590355dcf7478227
+guid: f17650341256229438b7ee1fe9828179
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Plugins/Rosetta/Editor/Custom/Creator/CreatorBaseEditor.cs
+++ b/Assets/Plugins/Rosetta/Editor/Custom/Creator/CreatorBaseEditor.cs
@@ -1,0 +1,84 @@
+using UnityEngine;
+using UnityEditor;
+using static UnityEditor.EditorGUILayout;
+using System;
+using System.Linq;
+using Rosetta.Editor.Creator;
+using Rosetta.Editor.Collector;
+
+namespace Rosetta.Editor.Custom.Creator
+{
+    [CustomEditor(typeof(CreatorBase), true)]
+    public class CreatorBaseEditor : UnityEditor.Editor
+    {
+        private static Type[] collectorTypes;
+
+        private void OnEnable()
+        {
+            collectorTypes = AppDomain.CurrentDomain.GetAssemblies().SelectMany(assem =>
+                assem.GetTypes().Where(type => type.IsSubclassOf(typeof(CollectorBase)) && !type.IsAbstract && !type.GetCustomAttributes(false).Any(attr => attr is HideInInspector))
+            ).ToArray();
+        }
+
+        public override void OnInspectorGUI()
+        {
+            var creator = target as CreatorBase;
+            var path = AssetDatabase.GetAssetPath(target);
+            var collectors = AssetDatabase.LoadAllAssetsAtPath(path);
+            var serCreators = serializedObject.FindProperty("Collectors");
+            serCreators.arraySize = Mathf.Max(0, collectors.Length - 1);
+
+            if (GUILayout.Button("Add Collector", GUILayout.Height(20)))
+            {
+                var menu = new GenericMenu();
+                foreach (var type in collectorTypes)
+                {
+                    menu.AddItem(new GUIContent(type.Name), false,
+                    () =>
+                    {
+                        var collector = CreateInstance(type);
+                        // collector.hideFlags |= HideFlags.HideInHierarchy;
+                        AssetDatabase.AddObjectToAsset(collector, target);
+                        AssetDatabase.SaveAssets();
+                    });
+                }
+                menu.ShowAsContext();
+            }
+
+            int idx = 0;
+            foreach (var item in collectors)
+            {
+                GUILayout.Space(20f);
+                if (item == target) continue;
+
+                serCreators.GetArrayElementAtIndex(idx++).objectReferenceValue = item;
+                // item.hideFlags = ShowSubObjs ? HideFlags.None : HideFlags.HideInHierarchy;
+
+                BeginHorizontal();
+                var itemName = item.GetType().Name;
+                LabelField(itemName, EditorStyles.boldLabel);
+                if (GUILayout.Button("Remove") && EditorUtility.DisplayDialog("Remove Collector", $"Are you sure you'd like to remove {itemName}?", "Yes", "No"))
+                {
+                    AssetDatabase.RemoveObjectFromAsset(item);
+                    AssetDatabase.SaveAssets();
+                    break;
+                }
+                EndHorizontal();
+                EditorGUI.indentLevel++;
+                var editor = CreateEditor(item);
+                editor.OnInspectorGUI();
+                EditorGUI.indentLevel--;
+            }
+
+            GUILayout.Space(30f);
+            serializedObject.ApplyModifiedProperties();
+
+            base.OnInspectorGUI();
+
+            if (GUILayout.Button("Create I18N file", GUILayout.Height(30)))
+                (target as CreatorBase).Create();
+            AssetDatabase.SaveAssets();
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/Plugins/Rosetta/Editor/Custom/Creator/CreatorBaseEditor.cs.meta
+++ b/Assets/Plugins/Rosetta/Editor/Custom/Creator/CreatorBaseEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 646b2cc529ec2a04fb43d1c190c748cd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Rosetta/Editor/Custom/Property.meta
+++ b/Assets/Plugins/Rosetta/Editor/Custom/Property.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9026c6b39d9c79f4590355dcf7478227
+guid: a9e7640c48f6b3946b2c179e241b6364
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Plugins/Rosetta/Editor/Custom/Property/FolderPathDrawer.cs
+++ b/Assets/Plugins/Rosetta/Editor/Custom/Property/FolderPathDrawer.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using UnityEditor;
+using Rosetta.Runtime;
+
+namespace Rosetta.Editor.Custom.Property
+{
+    [CustomPropertyDrawer(typeof(FolderPathAttribute), true)]
+    public class FolderPathDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.PropertyField(new Rect(position.x, position.y, position.width - 100, position.height),
+                                    property, label);
+            if (GUI.Button(new Rect(position.x + position.width - 80, position.y, 80, position.height), "Select"))
+            {
+                var selection = EditorUtility.OpenFolderPanel("Select Folder", property.stringValue, "Assets");
+                int assetIdx = selection.IndexOf("Assets");
+                if (selection.Trim().Length == 0) return;
+                if (assetIdx == -1)
+                    EditorUtility.DisplayDialog("Warning", "You need to specify a folder within the Assets folder.", "OK");
+                else property.stringValue = selection.Substring(assetIdx);
+            }
+        }
+    }
+}

--- a/Assets/Plugins/Rosetta/Editor/Custom/Property/FolderPathDrawer.cs.meta
+++ b/Assets/Plugins/Rosetta/Editor/Custom/Property/FolderPathDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e9e608183d21cb4fbc293dade25775d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Rosetta/Editor/Custom/RosettaRuntimeSettingEditor.cs
+++ b/Assets/Plugins/Rosetta/Editor/Custom/RosettaRuntimeSettingEditor.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using UnityEditor;
+using static UnityEditor.EditorGUILayout;
+using Rosetta.Runtime;
+using System.Collections.Generic;
+
+
+namespace Rosetta.Runtime.Custom
+{
+    [CustomEditor(typeof(RosettaRuntimeSetting))]
+    public class RosettaRuntimeSettingEditor : UnityEditor.Editor
+    {
+        private static Dictionary<string, I18NFileType> textFileType = new Dictionary<string, I18NFileType>()
+        {
+            {"Po", I18NFileType.Po}
+            //{"Mo", I18NFileType.Mo},
+            //{"CSV", I18NFileType.Csv},
+            //{"JSON", I18NFileType.Json},
+        };
+
+        public override void OnInspectorGUI()
+        {
+            var serSpaces = serializedObject.FindProperty("DefaultI18NSpaces");
+            PropertyField(serSpaces, true);
+
+            // DevLocale
+            var langNames = Rosetta.LangNames;
+            var displays = langNames.Select(i => $"{i.Value} ({i.Key})").ToArray();
+            var langValues = langNames.Select(i => i.Key).ToArray();
+            var serDevLocale = serializedObject.FindProperty("DevLocale");
+
+            var prevVal = serDevLocale.enumValueIndex;
+            var newVal = Popup("DevLocale", serDevLocale.enumValueIndex, displays);
+            if (prevVal != newVal && EditorUtility.DisplayDialog("Switch Dev Locale language?",
+                    "Are you sure you want to switch Dev Locale language?", "Switch", "Do Not Switch"))
+                serDevLocale.enumValueIndex = (int)langValues[newVal];
+
+            // TextFileType
+            displays = textFileType.Select(i => i.Key).ToArray();
+            var fileValues = textFileType.Select(i => i.Value).ToArray();
+            var serTextFileType = serializedObject.FindProperty("TextFileType");
+            serTextFileType.enumValueIndex = (int)fileValues[Popup("TextFileType", serTextFileType.enumValueIndex, displays)];
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/Plugins/Rosetta/Editor/Custom/RosettaRuntimeSettingEditor.cs.meta
+++ b/Assets/Plugins/Rosetta/Editor/Custom/RosettaRuntimeSettingEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83e3cac232c12494f86a802d1a84747f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Rosetta/Editor/Tests/CreatorTest.cs
+++ b/Assets/Plugins/Rosetta/Editor/Tests/CreatorTest.cs
@@ -1,10 +1,8 @@
 ﻿using System.Collections;
-using System.Collections.Generic;
 using NUnit.Framework;
-using UnityEngine;
 using UnityEngine.TestTools;
 
-namespace Rosetta.Editor.Tests
+namespace Rosetta.Runtime.Tests
 {
     public class CreatorTest
     {

--- a/Assets/Plugins/Rosetta/Runtime/Component/I18NComponentBase.cs
+++ b/Assets/Plugins/Rosetta/Runtime/Component/I18NComponentBase.cs
@@ -1,4 +1,4 @@
-using Sirenix.OdinInspector;
+// using Sirenix.OdinInspector;
 using UnityEngine;
 
 namespace Rosetta.Runtime.Component
@@ -8,7 +8,7 @@ namespace Rosetta.Runtime.Component
         /// <summary>
         ///     Comments to the translator will be used for the pot file "#." comment.
         /// </summary>
-        [MultiLineProperty] 
+        [Multiline(3)] 
         public string I18NComment = "";
 
         /// <summary>

--- a/Assets/Plugins/Rosetta/Runtime/Component/I18NImage.cs
+++ b/Assets/Plugins/Rosetta/Runtime/Component/I18NImage.cs
@@ -1,4 +1,4 @@
-using Sirenix.OdinInspector;
+// using Sirenix.OdinInspector;
 using UnityEngine;
 using UnityEngine.UI;
 #if UNITY_EDITOR
@@ -33,20 +33,5 @@ namespace Rosetta.Runtime.Component
             var image = gameObject.GetComponent<Image>();
             image.sprite = Rosetta.IsDefault() ? _devSprite : Rosetta.GetSprite(ResName, I18NSpace);
         }
-        
-#if UNITY_EDITOR
-
-        [OnInspectorGUI]
-        private void OnInspectorGUI()
-        {
-            if (EditorApplication.isPlaying) return;
-            TextureImporter textureImporter = AssetImporter.GetAtPath(AssetDatabase.GetAssetPath(gameObject.GetComponent<Image>().sprite.texture)) as TextureImporter;
-            if (!textureImporter.isReadable)
-                UnityEditor.EditorGUILayout.HelpBox("The Image source sprite is not readable.", UnityEditor.MessageType.Error);
-        }
-
-#endif
-
-
     }
 }

--- a/Assets/Plugins/Rosetta/Runtime/Component/I18NTMPText.cs
+++ b/Assets/Plugins/Rosetta/Runtime/Component/I18NTMPText.cs
@@ -1,4 +1,3 @@
-using Sirenix.OdinInspector;
 using TMPro;
 using UnityEngine;
 
@@ -17,11 +16,11 @@ namespace Rosetta.Runtime.Component
         /// <summary>
         ///      If true, the corresponding i18n font is loaded via the `VirtualFontName` instead of the currently set font.
         /// </summary>
-        public bool IsVirtualFont;
+        [HideInInspector] public bool IsVirtualFont;
         /// <summary>
         ///     I18n font name.
         /// </summary>
-        [ShowIf("IsVirtualFont")] public string VirtualFontName = "";
+        [HideInInspector] public string VirtualFontName = "";
 
         private void Start()
         {

--- a/Assets/Plugins/Rosetta/Runtime/Component/I18NText.cs
+++ b/Assets/Plugins/Rosetta/Runtime/Component/I18NText.cs
@@ -1,4 +1,3 @@
-using Sirenix.OdinInspector;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -17,12 +16,12 @@ namespace Rosetta.Runtime.Component
         /// <summary>
         ///      When this is true, the corresponding i18n font is loaded via the `VirtualFontName` instead of the currently set font.
         /// </summary>
-        public bool IsVirtualFont;
+        [HideInInspector] public bool IsVirtualFont;
 
         /// <summary>
         ///     I18n font name.
         /// </summary>
-        [ShowIf("IsVirtualFont")] public string VirtualFontName = "";
+        [HideInInspector] public string VirtualFontName = "";
 
         private void Start()
         {

--- a/Assets/Plugins/Rosetta/Runtime/FolderPathAttribute.cs
+++ b/Assets/Plugins/Rosetta/Runtime/FolderPathAttribute.cs
@@ -1,0 +1,14 @@
+using System;
+using UnityEngine;
+
+namespace Rosetta.Runtime
+{
+    /// <summary>
+    /// The substitude to Odin's [FolderPath] Attribute.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field)]
+    public class FolderPathAttribute : PropertyAttribute
+    {
+        public FolderPathAttribute() { }
+    }
+}

--- a/Assets/Plugins/Rosetta/Runtime/FolderPathAttribute.cs.meta
+++ b/Assets/Plugins/Rosetta/Runtime/FolderPathAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b17eac000eac7744b8af85242ea6cfff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Rosetta/Runtime/I18NAttribute.cs
+++ b/Assets/Plugins/Rosetta/Runtime/I18NAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace Rosetta.Runtime
 {
     [AttributeUsage(AttributeTargets.Field)]
-    public class I18NStringAttribute : Attribute
+    public class I18NStringAttribute : System.Attribute
     {
         public string Comment;
 
@@ -18,7 +18,7 @@ namespace Rosetta.Runtime
     }
     
     [AttributeUsage(AttributeTargets.Field)]
-    public class I18NStringListAttribute : Attribute
+    public class I18NStringListAttribute : System.Attribute
     {
         public string Comment;
 
@@ -33,7 +33,7 @@ namespace Rosetta.Runtime
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class I18NImageAttribute : Attribute
+    public class I18NImageAttribute : System.Attribute
     {
 
         public string Comment;
@@ -49,7 +49,7 @@ namespace Rosetta.Runtime
     }
     
     [AttributeUsage(AttributeTargets.Field)]
-    public class I18NImageListAttribute : Attribute
+    public class I18NImageListAttribute : System.Attribute
     {
 
         public string Comment;
@@ -65,7 +65,7 @@ namespace Rosetta.Runtime
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class I18NAudioAttribute : Attribute
+    public class I18NAudioAttribute : System.Attribute
     {
 
         public string Comment;
@@ -81,7 +81,7 @@ namespace Rosetta.Runtime
     }
 
     [AttributeUsage(AttributeTargets.Field)]
-    public class I18NAudioListAttribute : Attribute
+    public class I18NAudioListAttribute : System.Attribute
     {
 
         public string Comment;
@@ -97,7 +97,7 @@ namespace Rosetta.Runtime
     }
 
     [AttributeUsage(AttributeTargets.Class)]
-    public class I18NClassAttribute : Attribute
+    public class I18NClassAttribute : System.Attribute
     {
     }
 }

--- a/Assets/Plugins/Rosetta/Runtime/RosettaRuntimeSetting.cs
+++ b/Assets/Plugins/Rosetta/Runtime/RosettaRuntimeSetting.cs
@@ -1,53 +1,19 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using Sirenix.OdinInspector;
-using Sirenix.Utilities;
-using UnityEditor;
 using UnityEngine;
 
 namespace Rosetta.Runtime
 {
     [CreateAssetMenu(fileName = "RosettaRuntimeSetting", menuName = "Rosetta/RuntimeSetting")]
     [Serializable]
-    public class RosettaRuntimeSetting : SerializedScriptableObject
+    public class RosettaRuntimeSetting : ScriptableObject
     {
         public List<string> DefaultI18NSpaces = new List<string> { "UI" };
 
-        [ValueDropdown("langFlag")]
-        [OnValueChanged("SwitchDevLocale")]
         public LangFlag DevLocale = LangFlag.EN;
 
         [HideInInspector] public LangFlag Locale = LangFlag.EN;
 
-        [ValueDropdown("textFileType")] public I18NFileType TextFileType;
-
-#if UNITY_EDITOR
-        private LangFlag _devLocale;
-
-        private static IEnumerable langFlag()
-        {
-            var list = new ValueDropdownList<LangFlag>();
-            Rosetta.LangNames.ForEach(pair => list.Add(new ValueDropdownItem<LangFlag>($"{pair.Value} ({pair.Key.ToString()})", pair.Key)));
-            return list;
-        }
-        
-        private static IEnumerable textFileType = new ValueDropdownList<I18NFileType>
-        {
-            {"Po", I18NFileType.Po}
-            //{"Mo", I18NFileType.Mo},
-            //{"CSV", I18NFileType.Csv},
-            //{"JSON", I18NFileType.Json},
-        };
-
-        private void SwitchDevLocale()
-        {
-            if (EditorUtility.DisplayDialog("Switch Dev Locale language?",
-                "Are you sure you want to switch Dev Locale language?", "Switch", "Do Not Switch"))
-                _devLocale = DevLocale;
-            else
-                DevLocale = _devLocale;
-        }
-#endif
+        public I18NFileType TextFileType;
     }
 }

--- a/Assets/Plugins/Rosetta/Runtime/Utility.meta
+++ b/Assets/Plugins/Rosetta/Runtime/Utility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d3749bbb9244b754ca0646128e9e2354
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Rosetta/Runtime/Utility/IEnumerableExtension.cs
+++ b/Assets/Plugins/Rosetta/Runtime/Utility/IEnumerableExtension.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace Rosetta.Utils
+{
+    public static class IEnumerableExtension
+    {
+        public static void ForEach<T>(this IEnumerable<T> dict, Action<T> callback)
+        {
+            foreach (var pair in dict) callback?.Invoke(pair);
+        }
+    }
+}

--- a/Assets/Plugins/Rosetta/Runtime/Utility/IEnumerableExtension.cs.meta
+++ b/Assets/Plugins/Rosetta/Runtime/Utility/IEnumerableExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 369b50be2a66016488ea83bd14610881
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Odin 在插件的开发阶段相当强大，可以适应快速的开发进程，但对于中小型团队与项目而言，它实在是太贵、太臃肿了，且作为一个泛用的插件，应当考虑到在 Odin 不可用情况下的表现。  
在本 PR 中，所有的 Odin 代码均被替换为了等效的 Editor 拓展。部分界面与 Odin 有所差异，但提供的功能完全相同。